### PR TITLE
First migration to `RepetierClient`

### DIFF
--- a/src/Print3dServer.Core/Enums/Printer3dHeaterType.cs
+++ b/src/Print3dServer.Core/Enums/Printer3dHeaterType.cs
@@ -1,0 +1,10 @@
+﻿namespace AndreasReitberger.API.Print3dServer.Core.Enums
+{
+    public enum Printer3dHeaterType
+    {
+        Extruder,
+        HeatedBed,
+        HeatedChamber,
+        Other,
+    }
+}

--- a/src/Print3dServer.Core/Interfaces/IGcode.cs
+++ b/src/Print3dServer.Core/Interfaces/IGcode.cs
@@ -25,10 +25,10 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         #endregion
 
         #region Methods
-        public Task PrintAsync();
-        public Task ViewAsync();
-        public Task MoveToAsync(string targetPath, bool copy = false);
-        public Task MoveToQueueAsync(bool printIfReady = false);
+        public Task PrintAsync(IPrint3dServerClient client);
+        //public Task ViewAsync();
+        public Task MoveToAsync(IPrint3dServerClient client, string targetPath, bool copy = false);
+        public Task MoveToQueueAsync(IPrint3dServerClient client, bool printIfReady = false);
         #endregion
     }
 }

--- a/src/Print3dServer.Core/Interfaces/IHeaterComponent.cs
+++ b/src/Print3dServer.Core/Interfaces/IHeaterComponent.cs
@@ -1,4 +1,6 @@
-﻿namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
+﻿using AndreasReitberger.API.Print3dServer.Core.Enums;
+
+namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
 {
     public interface IHeaterComponent
     {
@@ -9,6 +11,13 @@
         public double TempRead { get; set; }
         public double TempSet { get; set; }
         public long Error { get; set; }
+
+        public Printer3dHeaterType Type { get; set; }
+        #endregion  
+
+        #region Methods
+
+        public Task<bool> SetTemperatureAsync(IPrint3dServerClient client, string command, object? data);
 
         #endregion
     }

--- a/src/Print3dServer.Core/Interfaces/IPrint3dBase.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrint3dBase.cs
@@ -6,10 +6,5 @@
         public Guid Id { get; set; }
 
         #endregion
-
-        #region Methods
-
-        public Task<bool> DeleteAsync();
-        #endregion
     }
 }

--- a/src/Print3dServer.Core/Interfaces/IPrint3dFan.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrint3dFan.cs
@@ -1,0 +1,17 @@
+﻿namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
+{
+    public interface IPrint3dFan
+    {
+        #region Properties
+        public bool On { get; set; }
+        public long? Voltage { get; set; }
+        public int? Speed { get; }
+        #endregion
+
+        #region Methods
+
+        public Task<bool> SetFanSpeedAsync(IPrint3dServerClient client, string command, object? data);
+
+        #endregion
+    }
+}

--- a/src/Print3dServer.Core/Interfaces/IPrint3dJob.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrint3dJob.cs
@@ -11,10 +11,10 @@
 
         #region Methods
 
-        public Task<bool> StartJobAsync();
-        public Task<bool> PauseJobAsync();
-        public Task<bool> StopJobAsync();
-        public Task<bool> RemoveFromQueueAsync();
+        public Task<bool> StartJobAsync(IPrint3dServerClient client, string command, object? data);
+        public Task<bool> PauseJobAsync(IPrint3dServerClient client, string command, object? data);
+        public Task<bool> StopJobAsync(IPrint3dServerClient client, string command, object? data);
+        public Task<bool> RemoveFromQueueAsync(IPrint3dServerClient client, string command, object? data);
 
         #endregion
     }

--- a/src/Print3dServer.Core/Interfaces/IPrint3dServerClient.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrint3dServerClient.cs
@@ -29,10 +29,13 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         public int DefaultTimeout { get; set; }
         public int RetriesWhenOffline { get; set; }
         public bool IsSecure { get; set; }
+        public bool OverrideValidationRules { get; set; }
         #endregion
 
         #region Auth
         Dictionary<string, IAuthenticationHeader> AuthHeaders { get; set; }
+        public bool LoginRequired { get; set; }
+        public bool AuthenticationFailed { get; set; }
         #endregion
 
         #region States
@@ -44,7 +47,6 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         public bool IsInitialized { get; set; }
         public bool IsListening { get; set; }
         public bool InitialDataFetched { get; set; }
-        public bool AuthenticationFailed { get; set; }
         public bool UpdateAvailable { get; set; }
         #endregion
 
@@ -82,12 +84,20 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         #region Printer States
         public IPrint3dJobStatus JobStatus { get; set; }
         public byte[] CurrentPrintImage { get; set; }
+
+        public double TemperatureExtruderMain { get; set; }
+        public double TemperatureExtruderSecondary { get; set; }
+        public double TemperatureHeatedBedMain { get; set; }
+        public double TemperatureHeatedChamberMain { get; set; }
+
         public double SpeedFactor { get; set; }
         public double SpeedFactorTarget { get; set; }
         public double FlowFactor { get; set; }
         public double FlowFactorTarget { get; set; }
+
         public long NumberOfToolHeads { get; set; }
         public long ActiveToolHead { get; set; }
+
         public bool IsMultiExtruder { get; set; }
         public bool HasHeatedBed { get; set; }
         public bool HasFan { get; set; }
@@ -109,6 +119,7 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         #region WebCam
         public bool HasWebCam { get; set; }
 
+        public IWebCamConfig SelectedWebCam { get; set; }
         #endregion
 
         #region Printer
@@ -136,6 +147,11 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         public ObservableCollection<IGcodeGroup> Groups { get; set; }
         public ObservableCollection<IGcode> Files { get; set; }
         public ObservableCollection<IPrint3dJob> Jobs { get; set; }
+        public ObservableCollection<IWebCamConfig> WebCams { get; set; }
+        public ObservableCollection<IPrint3dFan> Fans { get; set; }
+        public ObservableCollection<IHeaterComponent> Toolheads { get; set; }
+        public ObservableCollection<IHeaterComponent> HeatedBeds { get; set; }
+        public ObservableCollection<IHeaterComponent> HeatedChambers { get; set; }
         #endregion
 
         #region Methods
@@ -154,16 +170,20 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         #endregion
 
         #region Printer
-        public Task<bool> SendGcodeAsync(string command, object? data = null);
-        public Task<bool> HomeAsync(bool x, bool y, bool z);
+        public Task<bool> SendGcodeAsync(string command, object? data = null, string? targetUri = null);
+        public Task<bool> HomeAsync(bool x, bool y, bool z, string? targetUri = null);
+        public Task<bool> SetFanSpeedAsync(string command, object? data = null, string? targetUri = null);
+        public Task<bool> SetExtruderTemperatureAsync(string command, object? data = null, string? targetUri = null);
+        public Task<bool> SetBedTemperatureAsync(string command, object? data = null, string? targetUri = null);
+        public Task<bool> SetChamberTemperatureAsync(string command, object? data = null, string? targetUri = null);
         #endregion
 
         #region Jobs
-        public Task<bool> StartJobAsync(IPrint3dJob job, string command, object? data = null);
-        public Task<bool> RemoveJobAsync(IPrint3dJob job, string command, object? data = null);
-        public Task<bool> ContinueJobAsync(string command, object? data = null);
-        public Task<bool> PauseJobAsync(string command, object? data = null);
-        public Task<bool> StopJobAsync(string command, object? data = null);
+        public Task<bool> StartJobAsync(IPrint3dJob job, string command, object? data = null, string? targetUri = null);
+        public Task<bool> RemoveJobAsync(IPrint3dJob job, string command, object? data = null, string? targetUri = null);
+        public Task<bool> ContinueJobAsync(string command, object? data = null, string? targetUri = null);
+        public Task<bool> PauseJobAsync(string command, object? data = null, string? targetUri = null);
+        public Task<bool> StopJobAsync(string command, object? data = null, string? targetUri = null);
         #endregion
 
         #region Misc

--- a/src/Print3dServer.Core/Interfaces/IPrint3dServerClient.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrint3dServerClient.cs
@@ -88,6 +88,7 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         public double FlowFactorTarget { get; set; }
         public long NumberOfToolHeads { get; set; }
         public long ActiveToolHead { get; set; }
+        public bool IsMultiExtruder { get; set; }
         public bool HasHeatedBed { get; set; }
         public bool HasFan { get; set; }
         public bool HasHeatedChamber { get; set; }
@@ -138,17 +139,38 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         #endregion
 
         #region Methods
+
+        #region Proxy
+        public void SetProxy(bool secure, string address, int port, bool enable = true);
+        public void SetProxy(bool secure, string address, int port, string user = "", SecureString? password = null, bool enable = true);
+        #endregion
+
+        #region WebSocket
+        protected void PingServer(string? pingCommand = null);
+        public Task StartListeningAsync(string target, bool stopActiveListening = false, List<Task>? refreshFunctions = null);
+        public Task StopListeningAsync();
+        public Task ConnectWebSocketAsync(string target);
+        public Task DisconnectWebSocketAsync();
+        #endregion
+
+        #region Printer
         public Task<bool> SendGcodeAsync(string command, object? data = null);
-
         public Task<bool> HomeAsync(bool x, bool y, bool z);
+        #endregion
 
+        #region Jobs
         public Task<bool> StartJobAsync(IPrint3dJob job, string command, object? data = null);
         public Task<bool> RemoveJobAsync(IPrint3dJob job, string command, object? data = null);
         public Task<bool> ContinueJobAsync(string command, object? data = null);
         public Task<bool> PauseJobAsync(string command, object? data = null);
         public Task<bool> StopJobAsync(string command, object? data = null);
+        #endregion
+
+        #region Misc
 
         public void CancelCurrentRequests();
+        #endregion
+
         #endregion
     }
 }

--- a/src/Print3dServer.Core/Interfaces/IPrint3dServerClient.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrint3dServerClient.cs
@@ -49,8 +49,8 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         #endregion
 
         #region Api
-
         public string ApiVersion { get; set; }
+        public string ApiTargetPath { get; set; }
 
         #endregion
 
@@ -138,6 +138,16 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         #endregion
 
         #region Methods
+        public Task<bool> SendGcodeAsync(string command, object? data = null);
+
+        public Task<bool> HomeAsync(bool x, bool y, bool z);
+
+        public Task<bool> StartJobAsync(IPrint3dJob job, string command, object? data = null);
+        public Task<bool> RemoveJobAsync(IPrint3dJob job, string command, object? data = null);
+        public Task<bool> ContinueJobAsync(string command, object? data = null);
+        public Task<bool> PauseJobAsync(string command, object? data = null);
+        public Task<bool> StopJobAsync(string command, object? data = null);
+
         public void CancelCurrentRequests();
         #endregion
     }

--- a/src/Print3dServer.Core/Interfaces/IPrinter3d.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrinter3d.cs
@@ -37,7 +37,7 @@
 
         #region Methods
 
-        public Task<bool> HomeAsync(bool x, bool y, bool z);
+        public Task<bool> HomeAsync(IPrint3dServerClient client, bool x, bool y, bool z);
 
         #endregion
     }

--- a/src/Print3dServer.Core/Interfaces/IWebCamConfig.cs
+++ b/src/Print3dServer.Core/Interfaces/IWebCamConfig.cs
@@ -1,0 +1,13 @@
+﻿namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
+{
+    public interface IWebCamConfig
+    {
+        #region Properties
+        public string Alias { get; set; }
+        public Uri? WebCamUrlDynamic { get; set; }
+        public Uri? WebCamUrlStatic { get; set; }
+        public long Position { get; set; }
+        public long Orientation { get; set; }
+        #endregion
+    }
+}

--- a/src/Print3dServer.Core/Print3dServer.Core.csproj
+++ b/src/Print3dServer.Core/Print3dServer.Core.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="..\..\common.props" />
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.1;net6;net7</TargetFrameworks>
+	<TargetFrameworks>netstandard2.1;net6</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<RootNamespace>AndreasReitberger.API.Print3dServer.Core</RootNamespace>

--- a/src/Print3dServer.Core/Print3dServerClient.Events.cs
+++ b/src/Print3dServer.Core/Print3dServerClient.Events.cs
@@ -5,7 +5,6 @@ namespace AndreasReitberger.API.Print3dServer.Core
 {
     public partial class Print3dServerClient
     {
-
         #region EventHandlerss
 
         #region Debug

--- a/src/Print3dServer.Core/Print3dServerClient.Proxy.cs
+++ b/src/Print3dServer.Core/Print3dServerClient.Proxy.cs
@@ -1,0 +1,88 @@
+﻿using AndreasReitberger.API.Print3dServer.Core.Events;
+using System.Security;
+
+namespace AndreasReitberger.API.Print3dServer.Core
+{
+    public partial class Print3dServerClient
+    {
+
+        #region Properties
+        [ObservableProperty]
+        bool enableProxy = false;
+        partial void OnEnableProxyChanged(bool value)
+        {
+            UpdateRestClientInstance();
+        }
+
+        [ObservableProperty]
+        bool proxyUserUsesDefaultCredentials = true;
+        partial void OnProxyUserUsesDefaultCredentialsChanged(bool value)
+        {
+            UpdateRestClientInstance();
+        }
+
+        [ObservableProperty]
+        bool secureProxyConnection = true;
+        partial void OnSecureProxyConnectionChanged(bool value)
+        {
+            UpdateRestClientInstance();
+        }
+
+        [ObservableProperty]
+        string proxyAddress = string.Empty;
+        partial void OnProxyAddressChanged(string value)
+        {
+            UpdateRestClientInstance();
+        }
+
+        [ObservableProperty]
+        int proxyPort = 443;
+        partial void OnProxyPortChanged(int value)
+        {
+            UpdateRestClientInstance();
+        }
+
+        [ObservableProperty]
+        string proxyUser = string.Empty;
+        partial void OnProxyUserChanged(string value)
+        {
+            UpdateRestClientInstance();
+        }
+
+        [ObservableProperty]
+        SecureString? proxyPassword;
+        partial void OnProxyPasswordChanged(SecureString? value)
+        {
+            UpdateRestClientInstance();
+        }
+        #endregion
+
+        #region Methods
+
+        public void SetProxy(bool secure, string address, int port, bool enable = true)
+        {
+            EnableProxy = enable;
+            ProxyUserUsesDefaultCredentials = true;
+            ProxyAddress = address;
+            ProxyPort = port;
+            ProxyUser = string.Empty;
+            ProxyPassword = null;
+            SecureProxyConnection = secure;
+            UpdateRestClientInstance();
+        }
+
+        public void SetProxy(bool secure, string address, int port, string user = "", SecureString? password = null, bool enable = true)
+        {
+            EnableProxy = enable;
+            ProxyUserUsesDefaultCredentials = false;
+            ProxyAddress = address;
+            ProxyPort = port;
+            ProxyUser = user;
+            ProxyPassword = password;
+            SecureProxyConnection = secure;
+            UpdateRestClientInstance();
+        }
+
+        #endregion
+    }
+}

--- a/src/Print3dServer.Core/Print3dServerClient.WebSocket.cs
+++ b/src/Print3dServer.Core/Print3dServerClient.WebSocket.cs
@@ -66,7 +66,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
             }
         }
 
-        protected void PingServer(string? pingCommand = null)
+        public void PingServer(string? pingCommand = null)
         {
             try
             {
@@ -286,7 +286,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
             }
         }
 
-        void WebSocket_DataReceived(object? sender, DataReceivedEventArgs e)
+        protected void WebSocket_DataReceived(object? sender, DataReceivedEventArgs e)
         {
             try
             {

--- a/src/Print3dServer.Core/Print3dServerClient.cs
+++ b/src/Print3dServer.Core/Print3dServerClient.cs
@@ -546,7 +546,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
         }
         #endregion
 
-#endregion
+        #endregion
 
         #region Ctor
         public Print3dServerClient()
@@ -797,7 +797,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
             return apiRsponeResult;
         }
 
-        async Task<IRestApiRequestRespone?> SendOnlineCheckRestApiRequestAsync(
+        protected async Task<IRestApiRequestRespone?> SendOnlineCheckRestApiRequestAsync(
             string requestTargetUri,
             string command,
             Dictionary<string, IAuthenticationHeader> authHeaders,
@@ -856,7 +856,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
             return apiRsponeResult;
         }
 
-        async Task<IRestApiRequestRespone?> SendMultipartFormDataFileRestApiRequestAsync(
+        protected async Task<IRestApiRequestRespone?> SendMultipartFormDataFileRestApiRequestAsync(
             string filePath,
             Dictionary<string, string> authHeaders,
             string root = "/server/files/upload/",
@@ -938,7 +938,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
             return apiRsponeResult;
         }
 
-        async Task<IRestApiRequestRespone?> SendMultipartFormDataFileRestApiRequestAsync(
+        protected async Task<IRestApiRequestRespone?> SendMultipartFormDataFileRestApiRequestAsync(
             string fileName,
             byte[] file,
             Dictionary<string, string> authHeaders,

--- a/src/Print3dServer.Core/Print3dServerClient.cs
+++ b/src/Print3dServer.Core/Print3dServerClient.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Net;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace AndreasReitberger.API.Print3dServer.Core
 {
@@ -76,7 +77,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
 
         #region RefreshTimer
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         Timer timer;
 
         [ObservableProperty]
@@ -90,7 +91,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
         }
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool isListening = false;
         partial void OnIsListeningChanged(bool value)
         {
@@ -103,7 +104,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
         }
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool initialDataFetched = false;
 
         #endregion
@@ -133,10 +134,11 @@ namespace AndreasReitberger.API.Print3dServer.Core
         #region Connection
 
         [ObservableProperty]
+        [property: XmlIgnore]
         Dictionary<string, IAuthenticationHeader> authHeaders = new();
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         string sessionId = string.Empty;
 
         [ObservableProperty]
@@ -164,6 +166,32 @@ namespace AndreasReitberger.API.Print3dServer.Core
 
         [ObservableProperty]
         string apiKey = string.Empty;
+        partial void OnApiKeyChanged(string value)
+        {
+            switch (Target)
+            {
+                case Print3dServerTarget.Moonraker:
+                    break;
+                case Print3dServerTarget.RepetierServer:
+                    if (AuthHeaders?.ContainsKey("apikey") is true)
+                    {
+                        AuthHeaders["apikey"] = new AuthenticationHeader() { Token = value };
+                    }
+                    else
+                    {
+                        AuthHeaders?.Add("apikey", new AuthenticationHeader() { Token = value });
+                    }
+                    break;
+                case Print3dServerTarget.OctoPrint:
+                    break;
+                case Print3dServerTarget.PrusaConnect:
+                    break;
+                case Print3dServerTarget.Custom:
+                    break;
+                default:
+                    break;
+            }
+        }
 
         [ObservableProperty]
         string apiKeyRegexPattern = string.Empty;
@@ -182,7 +210,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
         bool overrideValidationRules = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool isOnline = false;
         partial void OnIsOnlineChanged(bool value)
         {
@@ -203,15 +231,15 @@ namespace AndreasReitberger.API.Print3dServer.Core
         }
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool isConnecting = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool authenticationFailed = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool isRefreshing = false;
 
         [ObservableProperty]
@@ -222,7 +250,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
         #region Update
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool updateAvailable = false;
         partial void OnUpdateAvailableChanged(bool value)
         {
@@ -254,46 +282,46 @@ namespace AndreasReitberger.API.Print3dServer.Core
         #region ConfigurationInfo
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         long activeToolHead = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         long numberOfToolHeads = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool isMultiExtruder = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool hasHeatedBed = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool hasHeatedChamber = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool hasFan = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool hasWebCam = false;
 
         #endregion
 
         #region PrinterState
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool isPrinting = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool isPaused = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool isConnectedPrinterOnline = false;
 
         #endregion
@@ -301,49 +329,49 @@ namespace AndreasReitberger.API.Print3dServer.Core
         #region Temperatures
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double temperatureExtruderMain = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double temperatureExtruderSecondary = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double temperatureHeatedBedMain = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double temperatureHeatedChamberMain = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double speedFactor = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double speedFactorTarget = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double flowFactor = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double flowFactorTarget = 0;
 
         #endregion
 
         #region Fans
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         int speedFanMain = 0;
 
         #endregion
 
         #region Printers
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         IPrinter3d? activePrinter;
         partial void OnActivePrinterChanging(IPrinter3d? value)
         {
@@ -357,7 +385,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
         }
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         ObservableCollection<IPrinter3d> printers = new();
         partial void OnPrintersChanged(ObservableCollection<IPrinter3d> value)
         {
@@ -371,7 +399,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
 
         #region Files
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         ObservableCollection<IGcodeGroup> groups = new();
         partial void OnGroupsChanged(ObservableCollection<IGcodeGroup> value)
         {
@@ -385,7 +413,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
         }
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         ObservableCollection<IGcode> files = new();
         partial void OnFilesChanged(ObservableCollection<IGcode> value)
         {
@@ -430,43 +458,82 @@ namespace AndreasReitberger.API.Print3dServer.Core
         }
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         IPrint3dJobStatus? jobStatus;
 
+        #endregion
+
+        #region WebCams
+
+        [ObservableProperty]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
+        IWebCamConfig selectedWebCam;
+
+        [ObservableProperty]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
+        ObservableCollection<IWebCamConfig> webCams = new();
+        #endregion
+
+        #region Fans
+
+        [ObservableProperty]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
+        ObservableCollection<IPrint3dFan> fans = new();
+        #endregion
+
+        #region Toolheads
+        [ObservableProperty]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
+        ObservableCollection<IHeaterComponent> toolheads = new();
+        #endregion
+
+        #region Beds
+
+        [ObservableProperty]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
+        ObservableCollection<IHeaterComponent> heatedBeds = new();
+
+        #endregion
+
+        #region Chambers
+
+        [ObservableProperty]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
+        ObservableCollection<IHeaterComponent> heatedChambers = new();
         #endregion
 
         #region Position
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double x = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double y = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         double z = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         int layer = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         int layers = 0;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool yHomed = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool zHomed = false;
 
         [ObservableProperty]
-        [property: JsonIgnore, XmlIgnore]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         bool xHomed = false;
 
         #endregion
@@ -688,12 +755,44 @@ namespace AndreasReitberger.API.Print3dServer.Core
 
                 if(authHeaders?.Count > 0)
                 {
-                    foreach (var header in authHeaders)
+                    switch (Target)
                     {
-                        //  "Authorization", $"Bearer {UserToken}"
-                        //  "X-Api-Key", $"{ApiKey}"
-                        request.AddHeader(header.Key, header.Value.Token);
+                        // Special handling for Repetier Server
+                        case Print3dServerTarget.RepetierServer:
+                            string? key = authHeaders?.FirstOrDefault(x => x.Key == "apikey").Value?.Token;
+                            request.AddParameter("apikey", key, ParameterType.QueryString);
+                            break;
+                        case Print3dServerTarget.Moonraker:
+                        case Print3dServerTarget.OctoPrint:
+                        case Print3dServerTarget.PrusaConnect:
+                        case Print3dServerTarget.Custom:       
+                        default:
+                            foreach (var header in authHeaders)
+                            {
+                                //  "Authorization", $"Bearer {UserToken}"
+                                //  "X-Api-Key", $"{ApiKey}"
+                                request.AddHeader(header.Key, header.Value.Token);
+                            }
+                            break;
                     }
+                }
+                switch (Target)
+                {
+                    case Print3dServerTarget.RepetierServer:
+                        if (string.IsNullOrEmpty(command)) break;
+                        urlSegments ??= new();
+                        urlSegments.Add("a", command);
+                        break;
+                    case Print3dServerTarget.Moonraker:
+                        break;
+                    case Print3dServerTarget.OctoPrint:
+                        break;
+                    case Print3dServerTarget.PrusaConnect:
+                        break;
+                    case Print3dServerTarget.Custom:
+                        break;
+                    default:
+                        break;
                 }
                 if (urlSegments != null)
                 {
@@ -1147,7 +1246,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
             }
         }
         
-        public async Task<bool> SendGcodeAsync(string command = "send", object? data = null)
+        public async Task<bool> SendGcodeAsync(string command = "send", object? data = null, string? targetUri = null)
         {
             try
             {
@@ -1157,7 +1256,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
                 };
                 IRestApiRequestRespone? result =
                     await SendRestApiRequestAsync(
-                        requestTargetUri: ApiTargetPath,
+                        requestTargetUri: targetUri ?? ApiTargetPath,
                         method: Method.Post,
                         command: command ?? "continueJob",
                         authHeaders: AuthHeaders,
@@ -1296,19 +1395,19 @@ namespace AndreasReitberger.API.Print3dServer.Core
         #endregion
 
         #region Toolheads
-        public async Task<bool> HomeAsync(bool x, bool y, bool z)
+        public async Task<bool> HomeAsync(bool x, bool y, bool z, string? targetUri = null)
         {
             try
             {
                 bool result;
                 if (x && y && z)
                 {
-                    result = await SendGcodeAsync(command: "send", new { cmd = "G28" }).ConfigureAwait(false);
+                    result = await SendGcodeAsync(command: "send", new { cmd = "G28" }, targetUri: targetUri).ConfigureAwait(false);
                 }
                 else
                 {
                     string cmd = string.Format("G28{0}{1}{2}", x ? " X0 " : "", y ? " Y0 " : "", z ? " Z0 " : "");
-                    result = await SendGcodeAsync(command: "send", new { cmd = cmd }).ConfigureAwait(false);
+                    result = await SendGcodeAsync(command: "send", new { cmd = cmd }, targetUri: targetUri).ConfigureAwait(false);
                 }
                 return result;
             }
@@ -1318,11 +1417,74 @@ namespace AndreasReitberger.API.Print3dServer.Core
             }
             return false;
         }
+
+        public async Task<bool> SetExtruderTemperatureAsync(string command = "setExtruderTemperature", object? data = null, string? targetUri = null)
+        {
+            try
+            {
+                IRestApiRequestRespone? result =
+                    await SendRestApiRequestAsync(
+                        requestTargetUri: targetUri ?? ApiTargetPath,
+                        method: Method.Post,
+                        command: command ?? "setExtruderTemperature",
+                        authHeaders: AuthHeaders,
+                        jsonObject: data)
+                    .ConfigureAwait(false);
+                return GetQueryResult(result.Result, true);
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return false;
+            }
+        }
+
+        public async Task<bool> SetBedTemperatureAsync(string command = "setBedTemperature", object? data = null, string? targetUri = null)
+        {
+            try
+            {
+                IRestApiRequestRespone? result =
+                    await SendRestApiRequestAsync(
+                        requestTargetUri: targetUri ?? ApiTargetPath,
+                        method: Method.Post,
+                        command: command ?? "setBedTemperature",
+                        authHeaders: AuthHeaders,
+                        jsonObject: data)
+                    .ConfigureAwait(false);
+                return GetQueryResult(result.Result, true);
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return false;
+            }
+        }
+
+        public async Task<bool> SetChamberTemperatureAsync(string command = "setChamberTemperature", object? data = null, string? targetUri = null)
+        {
+            try
+            {
+                IRestApiRequestRespone? result =
+                    await SendRestApiRequestAsync(
+                        requestTargetUri: targetUri ?? ApiTargetPath,
+                        method: Method.Post,
+                        command: command ?? "setChamberTemperature",
+                        authHeaders: AuthHeaders,
+                        jsonObject: data)
+                    .ConfigureAwait(false);
+                return GetQueryResult(result.Result, true);
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return false;
+            }
+        }
         #endregion
 
         #region Jobs
 
-        public async Task<bool> StartJobAsync(IPrint3dJob job, string command = "startJob", object? data = null)
+        public async Task<bool> StartJobAsync(IPrint3dJob job, string command = "startJob", object? data = null, string? targetUri = null)
         {
             try
             {
@@ -1333,7 +1495,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
                 };
                 IRestApiRequestRespone? result =
                     await SendRestApiRequestAsync(
-                        requestTargetUri: ApiTargetPath, 
+                        requestTargetUri: targetUri ?? ApiTargetPath, 
                         method: Method.Post, 
                         command: command ?? "continueJob", 
                         authHeaders: AuthHeaders, 
@@ -1348,7 +1510,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
             }
         }
 
-        public async Task<bool> RemoveJobAsync(IPrint3dJob job, string command = "removeJob", object? data = null)
+        public async Task<bool> RemoveJobAsync(IPrint3dJob job, string command = "removeJob", object? data = null, string? targetUri = null)
         {
             try
             {
@@ -1359,7 +1521,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
                 };
                 IRestApiRequestRespone? result =
                     await SendRestApiRequestAsync(
-                        requestTargetUri: ApiTargetPath,
+                        requestTargetUri: targetUri ?? ApiTargetPath,
                         method: Method.Post,
                         command: command ?? "removeJob",
                         authHeaders: AuthHeaders,
@@ -1374,13 +1536,13 @@ namespace AndreasReitberger.API.Print3dServer.Core
             }
         }
 
-        public async Task<bool> ContinueJobAsync(string command = "continueJob", object? data = null)
+        public async Task<bool> ContinueJobAsync(string command = "continueJob", object? data = null, string? targetUri = null)
         {
             try
             {
                 IRestApiRequestRespone? result =
                     await SendRestApiRequestAsync(
-                        requestTargetUri: ApiTargetPath,
+                        requestTargetUri: targetUri ?? ApiTargetPath,
                         method: Method.Post,
                         command: command ?? "continueJob",
                         authHeaders: AuthHeaders,
@@ -1395,13 +1557,13 @@ namespace AndreasReitberger.API.Print3dServer.Core
             }
         }
 
-        public async Task<bool> PauseJobAsync(string command = "pauseJob", object? data = null)
+        public async Task<bool> PauseJobAsync(string command = "pauseJob", object? data = null, string? targetUri = null)
         {
             try
             {
                 IRestApiRequestRespone? result =
                     await SendRestApiRequestAsync(
-                        requestTargetUri: ApiTargetPath,
+                        requestTargetUri: targetUri ?? ApiTargetPath,
                         method: Method.Post,
                         command: command ?? "pauseJob",
                         authHeaders: AuthHeaders,
@@ -1416,15 +1578,38 @@ namespace AndreasReitberger.API.Print3dServer.Core
             }
         }
 
-        public async Task<bool> StopJobAsync(string command = "continueJob", object? data = null)
+        public async Task<bool> StopJobAsync(string command = "continueJob", object? data = null, string? targetUri = null)
         {
             try
             {
                 IRestApiRequestRespone? result =
                     await SendRestApiRequestAsync(
-                        requestTargetUri: ApiTargetPath,
+                        requestTargetUri: targetUri ?? ApiTargetPath,
                         method: Method.Post,
                         command: command ?? "stopJob",
+                        authHeaders: AuthHeaders,
+                        jsonObject: data)
+                    .ConfigureAwait(false);
+                return GetQueryResult(result?.Result, true);
+            }
+            catch (Exception exc)
+            {
+                OnError(new UnhandledExceptionEventArgs(exc, false));
+                return false;
+            }
+        }
+        #endregion
+
+        #region Printer Control
+        public async Task<bool> SetFanSpeedAsync(string command = "setFanSpeed", object? data = null, string? targetUri = null)
+        {
+            try
+            {
+                IRestApiRequestRespone? result =
+                    await SendRestApiRequestAsync(
+                        requestTargetUri: targetUri ?? ApiTargetPath,
+                        method: Method.Post,
+                        command: command ?? "setFanSpeed",
                         authHeaders: AuthHeaders,
                         jsonObject: data)
                     .ConfigureAwait(false);

--- a/src/Print3dServer.Core/Print3dServerClient.cs
+++ b/src/Print3dServer.Core/Print3dServerClient.cs
@@ -5,7 +5,6 @@ using AndreasReitberger.Core.Utilities;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Net;
-using System.Security;
 using System.Text.RegularExpressions;
 
 namespace AndreasReitberger.API.Print3dServer.Core
@@ -13,9 +12,9 @@ namespace AndreasReitberger.API.Print3dServer.Core
     public partial class Print3dServerClient : ObservableObject, IPrint3dServerClient
     {
         #region Variables
-        RestClient? restClient;
-        HttpClient? httpClient;
-        int _retries = 0;
+        protected RestClient? restClient;
+        protected HttpClient? httpClient;
+        protected int _retries = 0;
         #endregion
 
         #region Properties
@@ -238,57 +237,6 @@ namespace AndreasReitberger.API.Print3dServer.Core
         
         #endregion
 
-        #region Proxy
-        [ObservableProperty]
-        bool enableProxy = false;
-        partial void OnEnableProxyChanged(bool value)
-        {
-            UpdateRestClientInstance();
-        }
-
-        [ObservableProperty]
-        bool proxyUserUsesDefaultCredentials = true;
-        partial void OnProxyUserUsesDefaultCredentialsChanged(bool value)
-        {
-            UpdateRestClientInstance();
-        }
-
-        [ObservableProperty]
-        bool secureProxyConnection = true;
-        partial void OnSecureProxyConnectionChanged(bool value)
-        {
-            UpdateRestClientInstance();
-        }
-
-        [ObservableProperty]
-        string proxyAddress = string.Empty;
-        partial void OnProxyAddressChanged(string value)
-        {
-            UpdateRestClientInstance();
-        }
-
-        [ObservableProperty]
-        int proxyPort = 443;
-        partial void OnProxyPortChanged(int value)
-        {
-            UpdateRestClientInstance();
-        }
-
-        [ObservableProperty]
-        string proxyUser = string.Empty;
-        partial void OnProxyUserChanged(string value)
-        {
-            UpdateRestClientInstance();
-        }
-
-        [ObservableProperty]
-        SecureString proxyPassword;
-        partial void OnProxyPasswordChanged(SecureString value)
-        {
-            UpdateRestClientInstance();
-        }
-        #endregion
-
         #region DiskSpace
         [ObservableProperty]
         long freeDiskSpace = 0;
@@ -315,7 +263,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
 
         [ObservableProperty]
         [property: JsonIgnore, XmlIgnore]
-        bool isDualExtruder = false;
+        bool isMultiExtruder = false;
 
         [ObservableProperty]
         [property: JsonIgnore, XmlIgnore]
@@ -1492,13 +1440,6 @@ namespace AndreasReitberger.API.Print3dServer.Core
 
         #endregion
 
-        #endregion
-
-        #region Interface, unused
-        public async Task<bool> DeleteAsync()
-        {
-            throw new NotSupportedException("This method is not supported on this object!");
-        }
         #endregion
 
         #region Overrides

--- a/src/Print3dServer.Core/Print3dServerConnectionBuilder.cs
+++ b/src/Print3dServer.Core/Print3dServerConnectionBuilder.cs
@@ -29,6 +29,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
             public Print3dServerConnectionBuilder AsOctoPrintServer()
             {
                 _client.Target = Print3dServerTarget.OctoPrint;
+                _client.ApiKeyRegexPattern = RegexHelper.OctoPrintApiKey;
                 return this;
             }
 
@@ -44,9 +45,10 @@ namespace AndreasReitberger.API.Print3dServer.Core
                 return this;
             }
 
-            public Print3dServerConnectionBuilder AsCustom()
+            public Print3dServerConnectionBuilder AsCustom(string apiKeyRegexPattern = "")
             {
                 _client.Target = Print3dServerTarget.Custom;
+                _client.ApiKeyRegexPattern = apiKeyRegexPattern;
                 return this;
             }
             

--- a/src/Print3dServer.Core/Print3dServerConnectionBuilder.cs
+++ b/src/Print3dServer.Core/Print3dServerConnectionBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using AndreasReitberger.API.Print3dServer.Core.Enums;
+using AndreasReitberger.Core.Utilities;
 
 namespace AndreasReitberger.API.Print3dServer.Core
 {
@@ -20,6 +21,8 @@ namespace AndreasReitberger.API.Print3dServer.Core
             public Print3dServerConnectionBuilder AsRepetierServer()
             {
                 _client.Target = Print3dServerTarget.RepetierServer;
+                _client.ApiKeyRegexPattern = RegexHelper.RepetierServerProApiKey;
+                _client.Port = 3344;
                 return this;
             }
 


### PR DESCRIPTION
The core library was used for the `RepetierClient` the first time.
Some adjustments have been made due to this migration.

Fixed #7 