### PR TITLE
Add common timebase for printtimes and timestamps

### DIFF
--- a/src/Print3dServer.Core/Enums/GcodeTimeBaseTarget.cs
+++ b/src/Print3dServer.Core/Enums/GcodeTimeBaseTarget.cs
@@ -1,0 +1,12 @@
+﻿namespace AndreasReitberger.API.Print3dServer.Core.Enums
+{
+    public enum GcodeTimeBaseTarget
+    {
+        DoubleHours,
+        DoubleSeconds,
+        DoubleHoursUnix,
+        DoubleSecondsUnix,
+        LongSeconds,
+        LongSecondsUnix,
+    }
+}

--- a/src/Print3dServer.Core/Interfaces/IGcode.cs
+++ b/src/Print3dServer.Core/Interfaces/IGcode.cs
@@ -10,10 +10,12 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         public string FilePath { get; set; }
         public string PrinterName { get; set; }
         public GcodeImageType ImageType { get; set; }
+        public GcodeTimeBaseTarget TimeBaseTarget { get; set; }
         public double Modified { get;set; }
         public double Volume { get;set; }
         public double Filament { get;set; }
         public double PrintTime { get;set; }
+        public TimeSpan? PrintTimeGeneralized { get;set; }
         public long Size { get; set; }
         public string Permissions { get; set; }
         public string Group { get; set; }

--- a/src/Print3dServer.Core/Interfaces/IPrint3dJob.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrint3dJob.cs
@@ -5,7 +5,9 @@
         #region Properties
         public string JobId { get; set; }
         public double? TimeAdded { get; set; }
+        public DateTime? TimeAddedGeneralized { get; set; }
         public double? TimeInQueue { get; set; }
+        public DateTime? TimeInQueueGeneralized { get; set; }
         public string FileName { get; set; }
         #endregion
 

--- a/src/Print3dServer.Core/Interfaces/IPrint3dJobStatus.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrint3dJobStatus.cs
@@ -8,10 +8,14 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         public string JobId { get; set; }
         public double? Done { get; set; }
         public double? StartTime { get; set; }
+        public DateTime? StartTimeGeneralized { get; set; }
         public double? EndTime { get; set; }
+        public DateTime? EndTimeGeneralized { get; set; }
         public double? FilamentUsed { get; set; }
         public double? PrintDuration { get; set; }
+        public TimeSpan? PrintDurationGeneralized { get; set; }
         public double? TotalPrintDuration { get; set; }
+        public TimeSpan? TotalPrintDurationGeneralized { get; set; }
         public string FileName { get; set; }
         public bool FileExists { get; set; }
         public Print3dJobState State { get; set; }

--- a/src/Print3dServer.Core/Interfaces/IPrint3dServerClient.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrint3dServerClient.cs
@@ -1,4 +1,5 @@
 ﻿using AndreasReitberger.API.Print3dServer.Core.Enums;
+using AndreasReitberger.API.Print3dServer.Core.Events;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Net;
@@ -174,6 +175,51 @@ namespace AndreasReitberger.API.Print3dServer.Core.Interfaces
         public ConcurrentDictionary<int, IToolhead> Toolheads { get; set; }
         public ConcurrentDictionary<int, IHeaterComponent> HeatedBeds { get; set; }
         public ConcurrentDictionary<int, IHeaterComponent> HeatedChambers { get; set; }
+        #endregion
+
+        #region EventHandlers
+        public event EventHandler<IgnoredJsonResultsChangedEventArgs> IgnoredJsonResultsChanged;
+
+        public event EventHandler<Print3dBaseEventArgs> WebSocketConnected;
+        public event EventHandler<Print3dBaseEventArgs> WebSocketDisconnected;
+        public event EventHandler<ErrorEventArgs> WebSocketError;
+        public event EventHandler<WebsocketEventArgs> WebSocketMessageReceived;
+        public event EventHandler<WebsocketEventArgs> WebSocketDataReceived;
+        public event EventHandler<LoginRequiredEventArgs> LoginResultReceived;
+
+        public event EventHandler<Print3dBaseEventArgs> ServerWentOffline;
+        public event EventHandler<Print3dBaseEventArgs> ServerWentOnline;
+        public event EventHandler<Print3dBaseEventArgs> ServerUpdateAvailable;
+
+        public event EventHandler Error;
+        public event EventHandler<RestEventArgs> RestApiError;
+        public event EventHandler<RestEventArgs> RestApiAuthenticationError;
+        public event EventHandler<RestEventArgs> RestApiAuthenticationSucceeded;
+        public event EventHandler<JsonConvertEventArgs> RestJsonConvertError;
+
+        public event EventHandler<ListeningChangedEventArgs> ListeningChanged;
+        public event EventHandler<SessionChangedEventArgs> SessionChanged;
+        public event EventHandler<JobStartedEventArgs> JobsStarted;
+        public event EventHandler<JobsChangedEventArgs> JobsChanged;
+        public event EventHandler<JobFinishedEventArgs> JobFinished;
+        public event EventHandler<JobStatusFinishedEventArgs> JobStatusFinished;
+        public event EventHandler<TemperatureDataEventArgs> TemperatureDataReceived;
+        public event EventHandler<GcodesChangedEventArgs> GcodesChanged;
+        public event EventHandler<GcodeGroupsChangedEventArgs> GcodeGroupsChanged;
+        public event EventHandler<ActivePrinterChangedEventArgs> ActivePrinterChanged;
+        public event EventHandler<ActivePrintImageChangedEventArgs> ActivePrintImageChanged;
+        public event EventHandler<JobListChangedEventArgs> JobListChanged;
+
+        public event EventHandler<PrintersChangedEventArgs> RemotePrintersChanged;
+
+        public event EventHandler<WebCamConfigChangedEventArgs> WebCamConfigChanged;
+        public event EventHandler<WebCamConfigsChangedEventArgs> WebCamConfigsChanged;
+
+        public event EventHandler<HeaterChangedEventArgs> HeaterChanged;
+        public event EventHandler<HeatersChangedEventArgs> HeatersChanged;
+
+        public event EventHandler<ToolheadChangedEventArgs> ToolheadChanged;
+        public event EventHandler<ToolheadsChangedEventArgs> ToolheadsChanged;
         #endregion
 
         #region Methods

--- a/src/Print3dServer.Core/Print3dServerClient.Events.cs
+++ b/src/Print3dServer.Core/Print3dServerClient.Events.cs
@@ -235,7 +235,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
 
         #endregion
 
-        #region Heaters
+        #region Toolheads
         public event EventHandler<ToolheadChangedEventArgs> ToolheadChanged;
         protected virtual void OnToolheadChangedEvent(ToolheadChangedEventArgs e)
         {

--- a/src/Print3dServer.Core/Print3dServerClient.cs
+++ b/src/Print3dServer.Core/Print3dServerClient.cs
@@ -28,6 +28,7 @@ namespace AndreasReitberger.API.Print3dServer.Core
         Print3dServerTarget target = Print3dServerTarget.Custom;
 
         [ObservableProperty]
+        [property: JsonIgnore, System.Text.Json.Serialization.JsonIgnore, XmlIgnore]
         Func<Task>? onRefresh;
         #endregion
 

--- a/src/Print3dServer.Core/Utilities/TimeBaseConvertHelper.cs
+++ b/src/Print3dServer.Core/Utilities/TimeBaseConvertHelper.cs
@@ -1,0 +1,140 @@
+﻿using AndreasReitberger.API.Print3dServer.Core.Enums;
+using System;
+
+namespace AndreasReitberger.API.Print3dServer.Core.Utilities
+{
+    public static class TimeBaseConvertHelper
+    {
+        #region Methods
+
+        public static TimeSpan? ConvertFrom<T>(GcodeTimeBaseTarget target, T value, bool withMiliSeconds = false)
+        {
+            TimeSpan? ts = target switch
+            {
+                GcodeTimeBaseTarget.DoubleHoursUnix or GcodeTimeBaseTarget.DoubleHours => (TimeSpan?)FromUnixDoubleHours(value as double?, withMiliSeconds),
+                GcodeTimeBaseTarget.DoubleSeconds or GcodeTimeBaseTarget.DoubleSecondsUnix => (TimeSpan?)FromDoubleSeconds(value as double?, withMiliSeconds),
+                GcodeTimeBaseTarget.LongSeconds or GcodeTimeBaseTarget.LongSecondsUnix => (TimeSpan?)FromLongSeconds(value as long?, withMiliSeconds),
+                _ => (TimeSpan?)TimeSpan.Zero,
+            };
+            return ts;
+        }
+
+        public static TimeSpan FromUnixDoubleHours(double? hours, bool withMiliSeconds = false)
+        {
+            try
+            {
+                TimeSpan ts = TimeSpan.FromSeconds(Convert.ToDouble(hours));
+                if (!withMiliSeconds)
+                    ts = new TimeSpan(ts.Days, ts.Hours, ts.Minutes, ts.Seconds);
+                return ts;
+            }
+            catch (Exception)
+            {
+                return TimeSpan.Zero;
+            }
+        }
+
+        public static TimeSpan FromDoubleHours(double? hours, bool withMiliSeconds = false) => FromUnixDoubleHours(hours, withMiliSeconds);
+
+        public static TimeSpan FromDoubleSeconds(double? seconds, bool withMiliSeconds = false)
+        {
+            try
+            {
+                TimeSpan ts = TimeSpan.FromSeconds(Convert.ToDouble(seconds));
+                if (!withMiliSeconds)
+                    ts = new TimeSpan(ts.Days, ts.Hours, ts.Minutes, ts.Seconds);
+                
+                return ts;
+            }
+            catch (Exception)
+            {
+                return TimeSpan.Zero;
+            }
+        }
+        public static TimeSpan FromLongSeconds(long? seconds, bool withMiliSeconds = false) => FromDoubleSeconds(Convert.ToDouble(seconds), withMiliSeconds);
+        public static TimeSpan FromLongSeconds(double? seconds, bool withMiliSeconds = false) => FromDoubleSeconds(seconds, withMiliSeconds);
+
+        public static DateTime FromUnixDoubleHoursToNow(double? hours, bool withMiliSeconds = false)
+        {
+            try
+            {
+                TimeSpan ts = TimeSpan.FromSeconds(Convert.ToDouble(hours));
+                if(!withMiliSeconds)
+                    ts = new TimeSpan(ts.Days, ts.Hours, ts.Minutes, ts.Seconds);
+                DateTime eta = DateTime.Now.Add(ts);
+                return eta;
+            }
+            catch (Exception)
+            {
+                return DateTime.Now;
+            }
+        }
+
+        public static DateTime FromDoubleSecondsToNow(double? seconds, bool withMiliSeconds = false)
+        {
+            try
+            {
+                TimeSpan ts = TimeSpan.FromSeconds(Convert.ToDouble(seconds));
+                if (!withMiliSeconds)               
+                    ts = new TimeSpan(ts.Days, ts.Hours, ts.Minutes, ts.Seconds);         
+                DateTime eta = DateTime.Now.Add(ts);
+                return eta;
+            }
+            catch (Exception)
+            {
+                return DateTime.Now;
+            }
+        }
+
+        public static DateTime FromUnixDate(double? unixDate)
+        {
+            try
+            {
+                DateTime dt = DateTime.MinValue;
+                TimeSpan ts = TimeSpan.FromSeconds(Convert.ToDouble(unixDate));
+                dt = new DateTime(1970, 1, 1, 0, 0, 0, 0).Add(ts).ToLocalTime();
+
+                return dt;
+            }
+            catch (Exception)
+            {
+                return DateTime.MinValue;
+            }
+        }
+
+        public static DateTime FromDouble(double? value)
+        {
+            try
+            {
+                DateTime dt = DateTime.MinValue;
+                TimeSpan ts = TimeSpan.FromMilliseconds(Convert.ToDouble(value));
+                dt = new DateTime(1970, 1, 1, 0, 0, 0, 0).Add(ts);
+
+                return dt;
+            }
+            catch (Exception)
+            {
+                return DateTime.MinValue;
+            }
+        }
+
+        public static DateTime FromLong(long? ms)
+        {
+            try
+            {
+                DateTime dt = DateTime.MinValue;
+                TimeSpan ts = TimeSpan.FromMilliseconds(Convert.ToDouble(ms));
+                dt = new DateTime(1970, 1, 1, 0, 0, 0, 0).Add(ts);
+
+                return dt;
+            }
+            catch (Exception)
+            {
+                return DateTime.MinValue;
+            }
+        }
+        public static DateTime FromInt(int? ms) => FromLong(ms);
+
+        #endregion
+    }
+}


### PR DESCRIPTION
To get a common timebase for `PrintDuration`, `Start`, `End` and so on, new properties have been added to the corresponding interfaces.
Also a `TimeBaseConvertHelper` has been introduced.

Fixed #29 