### PR TITLE
Fixed `IPrint3dTemperatureInfo`

### DIFF
--- a/src/Print3dServer.Core/Interfaces/IPrint3dTemperatureInfo.cs
+++ b/src/Print3dServer.Core/Interfaces/IPrint3dTemperatureInfo.cs
@@ -8,12 +8,5 @@
         public double? TemperatureTarget { get; set; }
 
         #endregion
-
-        #region Methods
-
-        public Task SetTemperatureAsync(double temperature);
-        public Task MoveAsync(double x, double y, double z);
-
-        #endregion
     }
 }


### PR DESCRIPTION
This PR removes unneeded methods from the interface.

```cs
        public Task SetTemperatureAsync(double temperature);
        public Task MoveAsync(double x, double y, double z);
```

Fixed #45