### PR TITLE
Fixed wrong `Auth` key for `Moonraker`

### DIFF
--- a/src/Print3dServer.Core/Print3dServerClient.Rest.cs
+++ b/src/Print3dServer.Core/Print3dServerClient.Rest.cs
@@ -154,7 +154,15 @@ namespace AndreasReitberger.API.Print3dServer.Core
                             {
                                 apiKey = authHeaders?.FirstOrDefault(x => x.Key == "oneshottoken").Value?.Token;
                                 if(apiKey is not null)
-                                    request.AddHeader("Authorization", $"Bearer {SessionId}");
+                                    //request.AddHeader("Authorization", $"Bearer {SessionId}");
+                                    request.AddHeader("Authorization", $"Bearer {apiKey}");
+                            }
+                            else if (authHeaders?.ContainsKey("usertoken") is true)
+                            {
+                                apiKey = authHeaders?.FirstOrDefault(x => x.Key == "usertoken").Value?.Token;
+                                if(apiKey is not null)
+                                    //request.AddHeader("Authorization", $"Bearer {SessionId}");
+                                    request.AddHeader("Authorization", $"Bearer {apiKey}");
                             }
                             else if (!string.IsNullOrEmpty(SessionId))
                             {


### PR DESCRIPTION
This PR fixes the wrong and missing parameters for authentication.

Fixed #55